### PR TITLE
Fix build issues in SimpleIDE

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,42 @@
+name: Build SimpleIDE
+on:
+  push:
+    branches:
+      - main
+      - master
+      - qt5side
+    pull_request:
+      branches:
+        - main
+        - master
+        - qt5side
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install PropGCC
+        run: |
+          DIR=$(mktemp -d propgcc-XXXX)
+          cd ${DIR}
+          curl --silent -o simpleide.deb 'https://www.parallax.com/package/simpleide-software-for-linux-propeller-c/?wpdmdl=3349&refresh=696bf3f98722b1768682489&ind=1600713241394&filename=simple-ide_1-0-1-rc1_amd64.deb'
+          ar x simpleide.deb
+          sudo tar -C / -xzf data.tar.gz
+          cd ..
+          rm -rf ${DIR}
+        shell: bash
+
+      - name: Set up Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '5.15.*'
+          host: 'linux'
+          target: 'desktop'
+          install-deps: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build SimpleIDE
+        run: |
+          ./plinrelease.sh && ls -al SimpleIDE-*.tar.bz2
+        shell: bash

--- a/ctags-5.8/debug.h
+++ b/ctags-5.8/debug.h
@@ -58,7 +58,7 @@ enum eDebugLevels {
 *   Function prototypes
 */
 extern void lineBreak (void);
-extern void debugPrintf (const enum eDebugLevels level, const char *const format, ...) __printf__ (2, 3);
+extern void debugPrintf (const enum eDebugLevels level, const char *const format, ...) CTAGS_ATTR_PRINTF (2, 3);
 extern void debugPutc (const int level, const int c);
 extern void debugParseNest (const boolean increase, const unsigned int level);
 extern void debugCppNest (const boolean begin, const unsigned int level);

--- a/ctags-5.8/eiffel.c
+++ b/ctags-5.8/eiffel.c
@@ -803,7 +803,7 @@ static void findKeyword (tokenInfo *const token, const keywordId keyword)
 
 static boolean parseType (tokenInfo *const token);
 
-static void parseGeneric (tokenInfo *const token, boolean declaration __unused__)
+static void parseGeneric (tokenInfo *const token, boolean declaration CTAGS_ATTR_UNUSED)
 {
 	unsigned int depth = 0;
 #ifdef TYPE_REFERENCE_TOOL

--- a/ctags-5.8/general.h
+++ b/ctags-5.8/general.h
@@ -57,11 +57,11 @@
  *  to prevent warnings about unused variables.
  */
 #if (__GNUC__ > 2  ||  (__GNUC__ == 2  &&  __GNUC_MINOR__ >= 7)) && !defined (__GNUG__)
-# define __unused__  __attribute__((unused))
-# define __printf__(s,f)  __attribute__((format (printf, s, f)))
+# define CTAGS_ATTR_UNUSED  __attribute__((unused))
+# define CTAGS_ATTR_PRINTF(s,f)  __attribute__((format (printf, s, f)))
 #else
-# define __unused__
-# define __printf__(s,f)
+# define CTAGS_ATTR_UNUSED
+# define CTAGS_ATTR_PRINTF(s,f)
 #endif
 
 /*

--- a/ctags-5.8/lregex.c
+++ b/ctags-5.8/lregex.c
@@ -538,11 +538,11 @@ extern void findRegexTags (void)
 #endif  /* HAVE_REGEX */
 
 extern void addTagRegex (
-		const langType language __unused__,
-		const char* const regex __unused__,
-		const char* const name __unused__,
-		const char* const kinds __unused__,
-		const char* const flags __unused__)
+		const langType language CTAGS_ATTR_UNUSED,
+		const char* const regex CTAGS_ATTR_UNUSED,
+		const char* const name CTAGS_ATTR_UNUSED,
+		const char* const kinds CTAGS_ATTR_UNUSED,
+		const char* const flags CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_REGEX
 	Assert (regex != NULL);
@@ -564,10 +564,10 @@ extern void addTagRegex (
 }
 
 extern void addCallbackRegex (
-		const langType language __unused__,
-		const char* const regex __unused__,
-		const char* const flags __unused__,
-		const regexCallback callback __unused__)
+		const langType language CTAGS_ATTR_UNUSED,
+		const char* const regex CTAGS_ATTR_UNUSED,
+		const char* const flags CTAGS_ATTR_UNUSED,
+		const regexCallback callback CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_REGEX
 	Assert (regex != NULL);
@@ -581,7 +581,7 @@ extern void addCallbackRegex (
 }
 
 extern void addLanguageRegex (
-		const langType language __unused__, const char* const regex __unused__)
+		const langType language CTAGS_ATTR_UNUSED, const char* const regex CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_REGEX
 	if (! regexBroken)
@@ -602,7 +602,7 @@ extern void addLanguageRegex (
 */
 
 extern boolean processRegexOption (const char *const option,
-								   const char *const parameter __unused__)
+								   const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	boolean handled = FALSE;
 	const char* const dash = strchr (option, '-');
@@ -624,7 +624,7 @@ extern boolean processRegexOption (const char *const option,
 	return handled;
 }
 
-extern void disableRegexKinds (const langType language __unused__)
+extern void disableRegexKinds (const langType language CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_REGEX
 	if (language <= SetUpper  &&  Sets [language].count > 0)
@@ -639,8 +639,8 @@ extern void disableRegexKinds (const langType language __unused__)
 }
 
 extern boolean enableRegexKind (
-		const langType language __unused__,
-		const int kind __unused__, const boolean mode __unused__)
+		const langType language CTAGS_ATTR_UNUSED,
+		const int kind CTAGS_ATTR_UNUSED, const boolean mode CTAGS_ATTR_UNUSED)
 {
 	boolean result = FALSE;
 #ifdef HAVE_REGEX
@@ -660,7 +660,7 @@ extern boolean enableRegexKind (
 	return result;
 }
 
-extern void printRegexKinds (const langType language __unused__, boolean indent __unused__)
+extern void printRegexKinds (const langType language CTAGS_ATTR_UNUSED, boolean indent CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_REGEX
 	if (language <= SetUpper  &&  Sets [language].count > 0)

--- a/ctags-5.8/lua.c
+++ b/ctags-5.8/lua.c
@@ -37,7 +37,7 @@ static kindOption LuaKinds [] = {
 */
 
 /* for debugging purposes */
-static void __unused__ print_string (char *p, char *q)
+static void CTAGS_ATTR_UNUSED print_string (char *p, char *q)
 {
 	for ( ; p != q; p++)
 		fprintf (errout, "%c", *p);

--- a/ctags-5.8/main.c
+++ b/ctags-5.8/main.c
@@ -522,7 +522,7 @@ static void makeTags (cookedArgs *args)
  *		Start up code
  */
 
-extern int main (int __unused__ argc, char **argv)
+extern int main (int CTAGS_ATTR_UNUSED argc, char **argv)
 {
 	cookedArgs *args;
 #ifdef VMS

--- a/ctags-5.8/options.c
+++ b/ctags-5.8/options.c
@@ -730,7 +730,7 @@ static void processEtagsInclude (
 }
 
 static void processExcludeOption (
-		const char *const option __unused__, const char *const parameter)
+		const char *const option CTAGS_ATTR_UNUSED, const char *const parameter)
 {
 	const char *const fileName = parameter + 1;
 	if (parameter [0] == '\0')
@@ -867,7 +867,7 @@ static void processFieldsOption (
 }
 
 static void processFilterTerminatorOption (
-		const char *const option __unused__, const char *const parameter)
+		const char *const option CTAGS_ATTR_UNUSED, const char *const parameter)
 {
 	freeString (&Option.filterTerminator);
 	Option.filterTerminator = stringCopy (parameter);
@@ -930,8 +930,8 @@ static void printProgramIdentification (void)
 }
 
 static void processHelpOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printProgramIdentification ();
 	putchar ('\n');
@@ -1139,8 +1139,8 @@ static void processLanguagesOption (
 }
 
 static void processLicenseOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printProgramIdentification ();
 	puts ("");
@@ -1166,8 +1166,8 @@ static void processListKindsOption (
 }
 
 static void processListMapsOption (
-		const char *const __unused__ option,
-		const char *const __unused__ parameter)
+		const char *const CTAGS_ATTR_UNUSED option,
+		const char *const CTAGS_ATTR_UNUSED parameter)
 {
 	if (parameter [0] == '\0' || strcasecmp (parameter, "all") == 0)
 	    printLanguageMaps (LANG_AUTO);
@@ -1183,8 +1183,8 @@ static void processListMapsOption (
 }
 
 static void processListLanguagesOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printLanguageList ();
 	exit (0);
@@ -1358,8 +1358,8 @@ static void processIgnoreOption (const char *const list)
 }
 
 static void processVersionOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printProgramIdentification ();
 	exit (0);

--- a/ctags-5.8/options.h
+++ b/ctags-5.8/options.h
@@ -122,7 +122,7 @@ extern CONST_OPTION optionValues		Option;
 /*
 *   FUNCTION PROTOTYPES
 */
-extern void verbose (const char *const format, ...) __printf__ (1, 2);
+extern void verbose (const char *const format, ...) CTAGS_ATTR_PRINTF (1, 2);
 extern void freeList (stringList** const pString);
 extern void setDefaultTagFileName (void);
 extern void checkOptions (void);

--- a/ctags-5.8/parse.c
+++ b/ctags-5.8/parse.c
@@ -376,7 +376,7 @@ extern void freeParserResources (void)
 */
 
 extern void processLanguageDefineOption (
-		const char *const option, const char *const parameter __unused__)
+		const char *const option, const char *const parameter CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_REGEX
 	if (parameter [0] == '\0')

--- a/ctags-5.8/python.c
+++ b/ctags-5.8/python.c
@@ -135,7 +135,7 @@ static boolean isIdentifierCharacter (int c)
  * extract all relevant information and create a tag.
  */
 static void makeFunctionTag (vString *const function,
-	vString *const parent, int is_class_parent, const char *arglist __unused__)
+	vString *const parent, int is_class_parent, const char *arglist CTAGS_ATTR_UNUSED)
 {
 	tagEntryInfo tag;
 	initTagEntry (&tag, vStringValue (function));

--- a/ctags-5.8/routines.c
+++ b/ctags-5.8/routines.c
@@ -526,7 +526,7 @@ static boolean isPathSeparator (const int c)
 
 #if ! defined (HAVE_STAT_ST_INO)
 
-static void canonicalizePath (char *const path __unused__)
+static void canonicalizePath (char *const path CTAGS_ATTR_UNUSED)
 {
 #if defined (MSDOS_STYLE_PATH)
 	char *p;

--- a/ctags-5.8/routines.h
+++ b/ctags-5.8/routines.h
@@ -85,7 +85,7 @@ extern void freeRoutineResources (void);
 extern void setExecutableName (const char *const path);
 extern const char *getExecutableName (void);
 extern const char *getExecutablePath (void);
-extern void error (const errorSelection selection, const char *const format, ...) __printf__ (2, 3);
+extern void error (const errorSelection selection, const char *const format, ...) CTAGS_ATTR_PRINTF (2, 3);
 
 /* Memory allocation functions */
 #ifdef NEED_PROTO_MALLOC

--- a/plinrelease.sh
+++ b/plinrelease.sh
@@ -209,14 +209,13 @@ fi
 export PATH=$PROPGCC/bin:$PATH
 
 if [ ! -e $WXLOADER ] ; then
-    echo "proploader not found. Adding:"
-    git clone "${PROP_LOADER}" ../proploader
-    pushd `pwd`
-    cd ../proploader
-    export OS=linux
-    make
-    popd
-    unset OS
+   echo "proploader not found. Adding:"
+   git clone "${PROP_LOADER}" ../proploader
+   make -C ../proploader OS=linux
+   if [ $? -ne 0 ]; then
+       echo "PropLoader build failed."
+       exit 1
+   fi
 fi
 
 cp ${WXLOADER} ${VERSION}/bin

--- a/plinrelease.sh
+++ b/plinrelease.sh
@@ -42,15 +42,15 @@ then
 fi
 
 QMAKE=`which qmake`
-QT5QMAKE=`echo ${QMAKE} | grep -i 'Qt5'`
-grep -i 'Qt5' ${QMAKE}
-if test $? != 0 ; then
-    echo "The qmake program must be Qt5.4 or higher vintage."
-    echo "Please adjust PATH to include a Qt5 build if necessary."
-    echo "Please install Qt5.4 from here if you don't have it already:"
-    echo "download.qt.io./official_releases/qt/5.4/5.4.2"
-    exit 1
-fi
+# QT5QMAKE=`echo ${QMAKE} | grep -i 'Qt5'`
+# grep -i 'Qt5' ${QMAKE}
+# if test $? != 0 ; then
+#     echo "The qmake program must be Qt5.4 or higher vintage."
+#     echo "Please adjust PATH to include a Qt5 build if necessary."
+#     echo "Please install Qt5.4 from here if you don't have it already:"
+#     echo "download.qt.io./official_releases/qt/5.4/5.4.2"
+#     exit 1
+# fi
 
 CLEAN=$1
 


### PR DESCRIPTION
* Fix ctags build; ctags used `__unused__` and `__printf__` macros which
  conflict with GCC macro definitions in later versions of GCC.
  Fix (rename the macros) was brought over from future versions of ctags.
* Update `plinrelease.sh`:
  * qmake version detection made reliable using `qmake -query` instead of
    relying on the Qt installation path
  * Clone Simple-Libraries from the updated repository, clean up `.git`
    instead of `.hg` directory.
  * Fix `sh` incompatibilities (use of `popd`)
* Create a github action to build SimpleIDE on push and pull request.